### PR TITLE
Update bcwc_pcie-9999.ebuild

### DIFF
--- a/media-video/bcwc_pcie/bcwc_pcie-9999.ebuild
+++ b/media-video/bcwc_pcie/bcwc_pcie-9999.ebuild
@@ -26,11 +26,12 @@ CONFIG_CHECK="VIDEO_V4L2 VIDEOBUF2_CORE VIDEOBUF2_DMA_SG"
 
 src_unpack() {
 	kernel_is -ge 4 8 && {
-		EGIT_BRANCH="mainline"
+		EGIT_BRANCH="master"
 	}
 	git-r3_src_unpack
 }
 
 src_prepare() {
+	eapply_user
 	sed -i "s#KDIR := /lib/modules/\$(KVERSION)/build#KDIR := ${KERNEL_DIR}#" Makefile
 }


### PR DESCRIPTION
Current ebuild pulls from a git tree that doesn't exist:
see: https://github.com/patjak/facetimehd/issues/197

Then complains that:
With EAPI 6, you must call eapply_user or default if you define src_prepare!
So I've added this.